### PR TITLE
Add CORS support for the rest API.

### DIFF
--- a/copilot_integration_example/api.py
+++ b/copilot_integration_example/api.py
@@ -9,8 +9,8 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],  # Adjust this to restrict origins if needed
     allow_credentials=False,  # Set to False if allow_origins remains ["*"], or list specific origins if True
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_headers=["Content-Type", "Authorization"]
 )
 
 


### PR DESCRIPTION

https://github.com/mannickutd/copilot-integration-example/issues/4

Add CORS support and by default support all domains for now.


This pull request introduces a small change to the `copilot_integration_example/api.py` file. It adds Cross-Origin Resource Sharing (CORS) middleware to the FastAPI application, enabling support for CORS with unrestricted origins, credentials, methods, and headers.

Key change:

* [`copilot_integration_example/api.py`](diffhunk://#diff-0b430c20c2c36ae4447d726a188c1fc12f9b57c9394dfc1505319ccc4442a1d6R2-R16): Added `CORSMiddleware` to the FastAPI application to enable CORS support.